### PR TITLE
Improve queries to prevent too many refetch and fixes

### DIFF
--- a/src/components/HealthBanner/HealthBanner.component.tsx
+++ b/src/components/HealthBanner/HealthBanner.component.tsx
@@ -1,24 +1,18 @@
 import { Box } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { memo, useEffect, useState } from 'react';
+import { memo } from 'react';
 import { checkHealth } from 'src/api/health';
 
 export const HealthBanner = memo(() => {
-  const [isHealthy, setIsHealthy] = useState(true);
-
-  const { data, isSuccess, isError } = useQuery({
+  const { data, isSuccess } = useQuery({
     queryKey: ['health'],
     queryFn: checkHealth,
-    retryDelay: 1000,
-    refetchInterval: 60000,
+    retry: true,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 30000), // Exponential backoff
+    staleTime: 60000,
   });
-  useEffect(() => {
-    if (isSuccess && data.status === 'UP') {
-      setIsHealthy(true);
-    } else setIsHealthy(false);
-  }, [isSuccess, data, isError]);
 
-  if (isHealthy) return null;
+  if (isSuccess && data?.status === 'UP') return null;
 
   return (
     <Box

--- a/src/components/modals/AddTraining.modal.tsx
+++ b/src/components/modals/AddTraining.modal.tsx
@@ -19,7 +19,7 @@ const AddTrainingModal: React.FC<AddTrainingModalProps> = ({
     mutationFn: ({ token, training }: { token: string; training: Training }) =>
       addTraining(token, training),
     onSuccess: () => {
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries({ queryKey: ['trainings'] });
       toast.success('Training added successfully');
       handleAddClose();
     },

--- a/src/hooks/useExerciseGridQueryHooks.ts
+++ b/src/hooks/useExerciseGridQueryHooks.ts
@@ -3,7 +3,7 @@ import {
   deleteExercise,
   getTrainingDetails,
   updateExercises,
-} from './training';
+} from '../api/training';
 import toast from 'react-hot-toast';
 import { ExerciseUpdate } from 'src/client/src';
 
@@ -27,7 +27,7 @@ export const useDeleteExercise = () => {
       exerciseId: string;
     }) => deleteExercise({ token, trainingId, exerciseId }),
     onSuccess: () => {
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries({ queryKey: ['exercises'] });
       toast.success('Exercise deleted successfully');
     },
   });
@@ -46,7 +46,7 @@ export const usePatchExercise = () => {
       trainingId: string;
     }) => updateExercises({ token, exerciseUpdate, trainingId }),
     onSuccess: () => {
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries({ queryKey: ['exercises'] });
       toast.success('Exercise updated successfully');
     },
   });

--- a/src/hooks/useUserMeasurements.ts
+++ b/src/hooks/useUserMeasurements.ts
@@ -11,7 +11,7 @@ export const useUserMeasurements = () => {
   const queryClient = useQueryClient();
 
   const { data, isSuccess, isError, status } = useQuery({
-    queryKey: ['Measurements'],
+    queryKey: ['Measurements', 'firstPage'],
     queryFn: () => getAllUserMeasurements({ token, pageParam: 0 }),
     retry: 0,
   });
@@ -24,8 +24,11 @@ export const useUserMeasurements = () => {
 
   const { mutate } = useMutation({
     mutationFn: addUserMeasurement,
-    onSuccess: (data) => {
-      queryClient.setQueryData(['Measurements'], data);
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['Measurements'],
+        refetchType: 'all',
+      });
       toast.success('Measurement added successfully');
     },
     onError: (error) => {

--- a/src/modules/Training/ExercisesGrid.component.tsx
+++ b/src/modules/Training/ExercisesGrid.component.tsx
@@ -26,7 +26,7 @@ import {
   useDeleteExercise,
   useGetTrainingDetails,
   usePatchExercise,
-} from 'src/api/exerciseGridQueryHooks';
+} from 'src/hooks/useExerciseGridQueryHooks';
 
 export default function ExerciseGrid() {
   const [rows, setRows] = useState<Rows[]>([]);

--- a/src/pages/User/userHistory.page.tsx
+++ b/src/pages/User/userHistory.page.tsx
@@ -11,7 +11,7 @@ function UserHistory() {
   const { token } = useAuth();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
     useInfiniteQuery({
-      queryKey: ['measurements'],
+      queryKey: ['Measurements', 'infinite'],
       queryFn: ({ pageParam }) => getAllUserMeasurements({ token, pageParam }),
       initialPageParam: 0,
       getNextPageParam: (lastPage, pages) => {

--- a/src/providers/ReactQuery.provider.tsx
+++ b/src/providers/ReactQuery.provider.tsx
@@ -2,7 +2,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ReactNode } from 'react';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30000,
+    },
+  },
+});
 
 export const ReactQueryProvider = ({ children }: { children: ReactNode }) => (
   <QueryClientProvider client={queryClient}>

--- a/src/providers/UserContext.provider.tsx
+++ b/src/providers/UserContext.provider.tsx
@@ -20,6 +20,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     queryKey: ['authToken'],
     queryFn: fetchToken,
     refetchInterval: 1000,
+    staleTime: 0,
+    notifyOnChangeProps: ['data'],
   });
 
   const login = useMutation<string, Error, string>({

--- a/src/utils/EditToolbar.tsx
+++ b/src/utils/EditToolbar.tsx
@@ -4,7 +4,7 @@ import { EditToolbarProps } from 'src/interfaces/exercises.interfaces';
 import AddIcon from '@mui/icons-material/Add';
 import CustomLink from 'src/components/Link/Link.component';
 import { motion } from 'framer-motion';
-import { usePatchExercise } from 'src/api/exerciseGridQueryHooks';
+import { usePatchExercise } from 'src/hooks/useExerciseGridQueryHooks';
 import useAuthStatus from 'src/hooks/useAuth';
 import { useCallback, useState } from 'react';
 


### PR DESCRIPTION
- Add staleTime to queryClient
- Add queryKey to invalidateQueries
- Change path of exerciseGridQueryHooks
- Change queryKeys in User Measurement page
- Invalidate queries instead of setting data on adding User Measurement
- Add exponential backoff to healthbar
- Delete unnecessary useState in healthBanner